### PR TITLE
Hydrate asset in bulk resize job

### DIFF
--- a/src/Actions/ResizeImages.php
+++ b/src/Actions/ResizeImages.php
@@ -19,7 +19,12 @@ class ResizeImages
     public function resizeImages(AssetCollection $assetCollection): void
     {
         $assetCollection->chunk($this->chunkSize)->each(function (AssetCollection $assets) {
-            $assets->each(fn (Asset $asset) => $asset->isImage() ? ResizeImageJob::dispatch($asset) : '');
+            $assets->each(function (Asset $asset) {
+                if($asset->isImage()) {
+                    $asset->hydrate();
+                    ResizeImageJob::dispatch($asset);
+                }
+            });
         });
     }
 }


### PR DESCRIPTION
This is needed to maintain meta data on the the ResizeImageJob